### PR TITLE
fix:Missing a space in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ You'll need to include something like
 [formula.js](https://github.com/sutoiku/formula.js/) to cover all the functions
 from Excel.
 
-##Install using npm
+## Install using npm
 npm install excel-formula
 
 ## Installation for web


### PR DESCRIPTION
Replacing
"##Install using npm"
with
"## Install using npm"